### PR TITLE
Support the linux cooked sll frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@ pcap_layers
 ===========
 
 A library for helping to process pcap files.  You can define callbacks for various layers of packet processing.
+
+Requires configure.ac:
+
+  AC_CHECK_HEADERS([pcap/sll.h])

--- a/pcap_layers.c
+++ b/pcap_layers.c
@@ -41,6 +41,10 @@
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
 
+#ifdef linux
+#include <pcap/sll.h>
+#endif
+
 #ifndef USE_IPV6
 #define USE_IPV6 1
 #endif
@@ -557,6 +561,28 @@ handle_ether(const u_char * pkt, int len, void *userdata)
     }
 }
 
+#ifdef linux
+void
+handle_linux_sll(const u_char * pkt, int len, void *userdata)
+{
+    struct sll_header *s = (struct sll_header *)pkt;
+    unsigned short etype, eproto;
+
+    if (len < SLL_HDR_LEN)
+        return;
+    etype = nptohs(&s->sll_pkttype);
+    if (etype == LINUX_SLL_BROADCAST || etype == LINUX_SLL_MULTICAST )
+        return;
+    eproto = nptohs(&s->sll_protocol);
+    if (eproto != ETHERTYPE_IP)
+        return;
+    pkt += SLL_HDR_LEN;
+    len -= SLL_HDR_LEN;
+    /* fprintf(stderr, "linnux cooked packet of len %d type %#04x proto %#04x\n", len, etype, eproto); */
+    handle_ip((struct ip *)pkt, len, userdata);
+}
+#endif
+
 void
 handle_pcap(u_char * userdata, const struct pcap_pkthdr *hdr, const u_char * pkt)
 {
@@ -586,6 +612,11 @@ pcap_layers_init(int dlt, int reassemble)
 #ifdef DLT_RAW
     case DLT_RAW:
         handle_datalink = handle_raw;
+        break;
+#endif
+#ifdef linux
+    case DLT_LINUX_SLL:
+        handle_datalink = handle_linux_sll;
         break;
 #endif
     case DLT_NULL:


### PR DESCRIPTION
On recent linux kernel, when we want to capture traffic on any interface, the frame will be encapsulated as linux cooked sll.
This patch support this kind of frame, to be able to run dsc with dsr like architecture.